### PR TITLE
Caw 782

### DIFF
--- a/caw_helper.module
+++ b/caw_helper.module
@@ -251,7 +251,9 @@ function caw_helper_custom_forward_template(&$variables) {
  * Implements hook_ds_pre_render_alter().
  */
 function caw_helper_ds_pre_render_alter(&$layout_render_array, $context) {
-  if ($context['entity']->type == 'stanford_news_item' && isset($layout_render_array['ds_content'][0])) {
+  if ($context['entity']->type == 'stanford_news_item'
+      && isset($context['entity']->service_links_rendered)
+      && isset($layout_render_array['ds_content'][0])) {
     $links = array();
     $links['service_links_rendered']['#type'] = 'markup';
     $links['service_links_rendered']['#prefix'] = $context['entity']->service_links_rendered;

--- a/caw_helper.module
+++ b/caw_helper.module
@@ -251,9 +251,7 @@ function caw_helper_custom_forward_template(&$variables) {
  * Implements hook_ds_pre_render_alter().
  */
 function caw_helper_ds_pre_render_alter(&$layout_render_array, $context) {
-  if ($context['entity']->type == 'stanford_news_item'
-      && isset($context['entity']->service_links_rendered)
-      && isset($layout_render_array['ds_content'][0])) {
+  if (isset($context['entity']->service_links_rendered) && isset($layout_render_array['ds_content'])) {
     $links = array();
     $links['service_links_rendered']['#type'] = 'markup';
     $links['service_links_rendered']['#prefix'] = $context['entity']->service_links_rendered;

--- a/caw_helper.module
+++ b/caw_helper.module
@@ -246,3 +246,15 @@ function caw_helper_custom_forward_template(&$variables) {
 
   return $output;
 }
+
+/**
+ * Implements hook_ds_pre_render_alter().
+ */
+function caw_helper_ds_pre_render_alter(&$layout_render_array, $context) {
+  if ($context['entity']->type == 'stanford_news_item' && isset($layout_render_array['ds_content'][0])) {
+    $links = array();
+    $links['service_links_rendered']['#type'] = 'markup';
+    $links['service_links_rendered']['#prefix'] = $context['entity']->service_links_rendered;
+    $layout_render_array['ds_content'][] = $links;
+  }
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
The Service Links module has a bug where if the view mode is using a display suite template file, the links are not passed to $ds_content and therefore don't show up. This ds alter hook adds them to the $ds_content variable and allows them to display on the content types selected on the Service Links Admin page(admin/config/services/service-links) even if they are using a ds template.

# Needed By (Date)
ASAP

# Urgency
HIGH

# Steps to Test

1. Clone cardinalatwork production to local for testing.
2. Put caw_helper module on branch CAW-782
3. Disable the context news_item_service_links(this currently places a block).
4. Clear Cache at least twice.
5. Check that a news item(which uses a ds template) still displays the service links(though not using the block in news_item_service_links context).

# Affected Projects or Products
This PR is isolated to cardinalatwork currently.

# Associated Issues and/or People
https://stanfordits.atlassian.net/browse/CAW-782